### PR TITLE
Add new error to ignored list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Add several new errors to ignored list
+
 ## 0.2.0 (2020-09-13)
 
 ### New Features

--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
@@ -27,3 +27,4 @@ Blocked autofocusing on a <input> element in a cross-origin subframe.
 /embed
 ResponsiveVoice missing API key
 /libfont/wasm/
+UserControls/Management

--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
@@ -28,3 +28,4 @@ Blocked autofocusing on a <input> element in a cross-origin subframe.
 ResponsiveVoice missing API key
 /libfont/wasm/
 UserControls/Management
+clientscript/


### PR DESCRIPTION
All happened in this test:
https://github.com/ONLYOFFICE/testing-documentserver/blob/468f8d1219d7f1e430c4b2b41c79fa6b168831e0/spec/modules/spreadsheets/spreadsheet_editor/autosave/collect_version_spec.rb#L9

Error like this:
```
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/smsc.svg - Failed to load resource: the server responded with a status of 502 ()"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/firebase.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/bitly.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/yahoo.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/easybib.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/wordpress.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/s3.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/googlecloud.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/rackspace.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/selectel.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/mailru.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/yandex.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/vk.svg - Failed to load resource: the server responded with a status of 502 ()"
"https://nacho.teamlab.info/UserControls/Management/AuthorizationKeys/img/telegram.svg - Failed to load resource: the server responded with a status of 502 ()"
```

And single other type:
```
"https://nacho.teamlab.info/clientscript/488YrvltC2Gv2clyZUJpag2_en-us.js?ver=11.0.0.4029XO-KJazkqtESvZSeeScbQ2 - Failed to load resource: the server responded with a status of 502 ()"]
```