### PR TITLE
Fix default xpath for iframe

### DIFF
--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/management.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/management.rb
@@ -16,7 +16,7 @@ module OnlyofficeDocumentserverTestingFramework
       @instance = instance
       @xpath_iframe_count = 1
       # Don't mixup iframe with help
-      @xpath_iframe = '//iframe[not(contains(@src, "help")) and '\
+      @xpath_iframe = '//iframe[not(contains(@src, "/help/")) and '\
                                'not(contains(@id, "fileFrame"))]'
       @alert_dialog_xpath = '//div[@role="alertdialog"]'
       @alert_dialog_span_xpath = "#{@alert_dialog_xpath}/div/div/div/span"


### PR DESCRIPTION
This should only filter out document editor help frame
Not editors on portal helpcenter.onlyoffice.com
Found by this test:
https://github.com/ONLYOFFICE/testing-onlyoffice/blob/bafbde7a883591e7498e9cd13651a9740ffd4c46/spec/site/multi_lang/functional/get_onlyoffice/site_registration_signin_spec.rb#L41