### PR TITLE
Use actual image -ee instead of deprecated -ie

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -24,8 +24,8 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Run DocumentServer
       run: |
-        docker run -id -p 80:80 --name documentserver onlyoffice/documentserver-ie:latest
-        sleep 60
+        docker run -id -p 80:80 --name documentserver onlyoffice/documentserver-ee:latest
+        sleep 120
         docker exec -i documentserver supervisorctl start all
     - name: Build and test with Rake
       run: |

--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions.rb
@@ -228,7 +228,7 @@ class DocTestSiteFunctions
 
   # @param [DocumentServerVersion] version of server
   # @return [Array<String>] list of supported languages
-  def self.supported_languages(version = OnlyofficeDocumentserverTestingFramework::DocumentServerVersion.new)
+  def self.supported_languages(version = OnlyofficeDocumentserverTestingFramework::DocumentServerVersion.new(6, 2, 0))
     file = if version >= OnlyofficeDocumentserverTestingFramework::DocumentServerVersion.new(6, 2)
              'doc_test_site_languages_after_6_2.list'
            else


### PR DESCRIPTION
Also increase start timeout, since latest version are slower to start