### PR TITLE
New design of test example were implemented on develop

### DIFF
--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions.rb
@@ -18,7 +18,7 @@ class DocTestSiteFunctions
     @xpath_file_loading_step = '//*[@id="step1"]'
     @xpath_conversion_step = '//*[@id="step2"]'
     @xpath_editor_scripts_step = '//*[@id="step3"]'
-    @xpath_file_entry = '//*[@class="stored-list"]/table/tbody/tr'
+    @xpath_file_entry = '//*[@class="stored-list"]//table/tbody/tr'
     @xpath_create_doc = '//*[contains(@class, "try-editor document")]|'\
                         '//*[contains(@class, "try-editor word")]'
     @xpath_create_workbook = '//*[contains(@class, "try-editor spreadsheet")]|'\


### PR DESCRIPTION
Since:
https://github.com/ONLYOFFICE/document-server-integration/pull/134

Not much changed in xpath, but design is completely new:
![image](https://user-images.githubusercontent.com/668524/113410329-d6645880-93bb-11eb-8659-fd338ef10edc.png)
