### PR TITLE
Drop support of `ruby-2.4` since it's EOLed more than year ago

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * New method to get doc name `TitleRow#document_name`
 
+### Changes
+
+* Drop support of `ruby-2.4` since it's EOLed more than year ago
+
 ## 0.4.0 (2021-04-02)
 
 ### New Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     onlyoffice_s3_wrapper (0.4.0)
       aws-sdk-s3 (~> 1)
       onlyoffice_file_helper (~> 0)
-    onlyoffice_webdriver_wrapper (0.12.0)
+    onlyoffice_webdriver_wrapper (0.13.0)
       headless (~> 2)
       onlyoffice_file_helper (~> 0)
       onlyoffice_logger_helper (~> 1)

--- a/onlyoffice_documentserver_testing_framework.gemspec
+++ b/onlyoffice_documentserver_testing_framework.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = OnlyofficeDocumentserverTestingFramework::Name::STRING
   s.version = OnlyofficeDocumentserverTestingFramework::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
   s.authors = ['ONLYOFFICE', 'Pavel Lobashov']
   s.summary = 'ONLYOFFICE DocumentServer testing framework'
   s.description = 'ONLYOFFICE DocumentServer testing framework, used in QA'


### PR DESCRIPTION
Update onlyoffice_webdriver_wrapper
Without it tests cannot be run