### PR TITLE
Support for waiting to load Mobile Editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New Features
+
+* Support for waiting to load Mobile Editors changed in DocumentServer v6.4
+
 ## 0.5.1 (2021-05-12)
 
 ### Fixes

--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/management.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/management.rb
@@ -59,6 +59,7 @@ module OnlyofficeDocumentserverTestingFramework
     def wait_for_mobile_loading
       @instance.selenium.element_visible?('//*[contains(@class,"modal-preloader")]') ||
         @instance.selenium.element_visible?('//*[contains(@class,"loader-page")]') ||
+        @instance.selenium.element_visible?('//div[contains(@class, "dialog-preloader")]') ||
         @instance.selenium.get_element('//*[contains(@class,"iScrollVerticalScrollbar")]').nil?
     end
 


### PR DESCRIPTION
This was changed in DocumentServer v6.4