### PR TITLE
Fix healthcheck url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Fix `\` in `healthcheck` url
+
 ## 0.6.0 (2021-07-22)
 
 ### New Feature

--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions.rb
@@ -209,7 +209,7 @@ class DocTestSiteFunctions
 
   # @return [Nothing]
   def go_to_healthcheck
-    @instance.webdriver.open("#{@instance.user_data.portal}/healthcheck")
+    @instance.webdriver.open("#{@instance.user_data.portal}healthcheck")
   end
 
   # @return [HealthcheckPage] page of healthcheck


### PR DESCRIPTION
Since:
https://github.com/ONLYOFFICE/testing-documentserver/pull/5285
It always ending with `/` so no need to add it in this method