### PR TITLE
Fix order of comment and review mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Fix order of `comment` and `review` mode on test example
+
 ## 0.6.2 (2021-08-27)
 
 ### Fixes

--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions/doc_test_file_list/doc_test_site_file_list_entry.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_test_site_functions/doc_test_file_list/doc_test_site_file_list_entry.rb
@@ -44,7 +44,7 @@ class DocTestSiteFileListEntry
 
   # @return [String] url on review mode
   def fetch_review_mode_url
-    xpath_review = "#{@xpath_line}/td[4]/a"
+    xpath_review = "#{@xpath_line}/td[#{mode_indexes[:review_mode]}]/a"
     return nil unless @instance.selenium.element_present?(xpath_review)
 
     url = @instance.selenium.get_attribute(xpath_review, 'href')
@@ -54,7 +54,7 @@ class DocTestSiteFileListEntry
 
   # @return [String] url on review mode
   def fetch_comment_mode_url
-    xpath_comment = "#{@xpath_line}/td[5]/a"
+    xpath_comment = "#{@xpath_line}/td[#{mode_indexes[:comment_mode]}]/a"
     return nil unless @instance.selenium.element_present?(xpath_comment)
 
     url = @instance.selenium.get_attribute(xpath_comment, 'href')
@@ -64,7 +64,7 @@ class DocTestSiteFileListEntry
 
   # @return [String] url on fill forms mode
   def fetch_fill_forms_mode_url
-    xpath_comment = "#{@xpath_line}/td[6]/a"
+    xpath_comment = "#{@xpath_line}/td[#{mode_indexes[:fill_forms]}]/a"
     return nil unless @instance.selenium.element_present?(xpath_comment)
 
     url = @instance.selenium.get_attribute(xpath_comment, 'href')
@@ -74,7 +74,7 @@ class DocTestSiteFileListEntry
 
   # @return [String] url on fill forms mode
   def fetch_only_fill_forms_mode_url
-    link_xpath = "#{@xpath_line}/td[7]/a"
+    link_xpath = "#{@xpath_line}/td[#{mode_indexes[:only_fill_forms]}]/a"
     return nil unless @instance.selenium.element_present?(link_xpath)
 
     url = @instance.selenium.get_attribute(link_xpath, 'href')
@@ -84,7 +84,7 @@ class DocTestSiteFileListEntry
 
   # @return [String] url on viewer mode
   def fetch_view_mode_url
-    xpath_comments = "#{@xpath_line}/td[8]/a"
+    xpath_comments = "#{@xpath_line}/td[#{mode_indexes[:view_mode]}]/a"
     return nil unless @instance.selenium.element_present?(xpath_comments)
 
     url = @instance.selenium.get_attribute(xpath_comments, 'href')
@@ -94,8 +94,23 @@ class DocTestSiteFileListEntry
 
   # @return [String] url on embedded file
   def fetch_embedded_url
-    url = @instance.selenium.get_attribute("#{@xpath_line}/td[10]/a", 'href')
+    url = @instance.selenium.get_attribute("#{@xpath_line}/td[#{mode_indexes[:embedded]}]/a", 'href')
     OnlyofficeLoggerHelper.log("Got embedded #{@xpath_line} url: #{url}")
     url
+  end
+
+  private
+
+  # Indexes of different modes
+  # @return [Hash] name with index
+  def mode_indexes
+    {
+      comment_mode: 4,
+      review_mode: 5,
+      fill_forms: 6,
+      only_fill_forms: 7,
+      view_mode: 8,
+      embedded: 10
+    }
   end
 end


### PR DESCRIPTION
This was changed in:
https://github.com/ONLYOFFICE/document-server-integration/commit/0ae02d8af9d6f3765d3ddf6cbef41640556c644e#diff-cb6c891b688e4abedba1cf56eeb95c384efd16e98ab9be44eaeef131633ee3dcR182
I don't think it's such important thing, so I will not add versioning