### PR TITLE
Fix compatibility issue with ruby 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ jobs:
     continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1']
         allow-failures: [false]
         include:
           - ruby: head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Drop support of `ruby-2.6`
+
 ## 1.0.0 (2022-01-21)
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-* Drop support of `ruby-2.6`
+* Drop support of `ruby-2.6`/ Fix compatibility with `ruby-3.1`
 
 ## 1.0.0 (2022-01-21)
 

--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper.rb
@@ -11,9 +11,9 @@ module OnlyofficeDocumentserverTestingFramework
     # @param name [Symbol] function to call
     # @param arguments [Hash] list of arguments
     # @return [Object] result of method
-    def selenium_functions(name, *arguments)
+    def selenium_functions(name, *arguments, **options)
       select_frame do
-        @instance.selenium.send name, *arguments
+        @instance.selenium.send name, *arguments, **options
       end
     end
 

--- a/onlyoffice_documentserver_testing_framework.gemspec
+++ b/onlyoffice_documentserver_testing_framework.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = OnlyofficeDocumentserverTestingFramework::Name::STRING
   s.version = OnlyofficeDocumentserverTestingFramework::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
   s.authors = ['ONLYOFFICE', 'Pavel Lobashov']
   s.summary = 'ONLYOFFICE DocumentServer testing framework'
   s.description = 'ONLYOFFICE DocumentServer testing framework, used in QA'


### PR DESCRIPTION
Method selenium_functions works on ruby 2.6 and fails on ruby 3.1 when the last argument looks like `option: value`

For example:
```
selenium_functions :click_on_locator, "#{@symbols_table_xpath}/div[#{number}]", false, count: 2
```