### PR TITLE
Actualize `nodejs` version in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+        with:
+          node-version: '16'
       - name: Check markdown files using `markdownlint`
         run: |
           npm install -g markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Fixes
+
+* Actualize `nodejs` version in CI
+
 ## 2.1.0 (2022-02-04)
 
 ### New Features


### PR DESCRIPTION
Without it `markdownlint-cli` sarted to fail