### PR TITLE
`click_on_displayed_button` do not wait for button to appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * Ignore `.rake_tasks~` autocomplete file
+* `click_on_displayed_button` do not wait for button to appear
 
 ## 2.11.0 (2022-08-19)
 

--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper.rb
@@ -91,7 +91,6 @@ module OnlyofficeDocumentserverTestingFramework
     # @param xpath [String] xpath to click
     # @return [nil]
     def click_on_displayed_button(xpath)
-      selenium_functions(:wait_until_element_visible, xpath)
       selenium_functions(:click_on_displayed, xpath)
     end
 


### PR DESCRIPTION
Previous variant has `wait_element` instead of
`wait_until_element_visible`
And this case just timeout on wait_element without any error
if there is several elements with same xpath

But current variant is failing, since for example on page there is two
elements and only a second one visible, so
`wait_until_element_visible` is failing

I think proper way is not wait for any element at all and handle waiting
in some other place