### PR TITLE
Exception warning in js console

### DIFF
--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
@@ -29,3 +29,4 @@ ResponsiveVoice missing API key
 /libfont/wasm/
 UserControls/Management
 clientscript/
+was loaded over an insecure connection. This file should be served over HTTPS.


### PR DESCRIPTION
In Chrome versions above 114. When downloading a file from a document server on an http connection, a warning: 'was loaded over an insecure connection. This file should be served over HTTPS.'