### PR TITLE
Add closing tooltips when open editor tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Changes from `rubocop-1.63.2` update
 * Fix `rubocop-1.64` cop `Style/SuperArguments` warnings.
+* Add closing tooltips when open editor tab
 
 ## 2.16.0 (2024-02-21)
 

--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_editor/doc_editor_top_toolbar/home_tab/editor_tab.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_editor/doc_editor_top_toolbar/home_tab/editor_tab.rb
@@ -51,6 +51,8 @@ module OnlyofficeDocumentserverTestingFramework
       close_tooltips
     end
 
+    # Close tooltips
+    # @return [Nothing]
     def close_tooltips
       click_on_button(close_tooltip_xpath) while visible?(tooltip_xpath)
     end

--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_editor/doc_editor_top_toolbar/home_tab/editor_tab.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/doc_editor/doc_editor_top_toolbar/home_tab/editor_tab.rb
@@ -47,10 +47,25 @@ module OnlyofficeDocumentserverTestingFramework
     # rubocop disable to not change interface of public method
     # rubocop:disable Style/OptionalBooleanParameter
     def open(to_open = true)
-      return if to_open == active?
+      click if to_open != active?
+      close_tooltips
+    end
 
-      click
+    def close_tooltips
+      click_on_button(close_tooltip_xpath) while visible?(tooltip_xpath)
     end
     # rubocop:enable Style/OptionalBooleanParameter
+
+    private
+
+    # @return [String] xpath to tooltip
+    def tooltip_xpath
+      "//div[contains(@class, 'synch-tip-root')]"
+    end
+
+    # @return [String] xpath to close button in tooltip
+    def close_tooltip_xpath
+      "#{tooltip_xpath}//div[@class = 'close']"
+    end
   end
 end


### PR DESCRIPTION
Tooltips for new features were added in https://github.com/ONLYOFFICE/web-apps/commit/6477b16040a44a865da28e0db1b4b662dff37da7